### PR TITLE
Fixed a Fatal Error caused by property visibility

### DIFF
--- a/models/datasources/soap_source.php
+++ b/models/datasources/soap_source.php
@@ -56,7 +56,7 @@ class SoapSource extends DataSource {
  * @var array
  * @access protected
  */
-	protected $_baseConfig = array(
+	public $_baseConfig = array(
 		'wsdl' => null,
 		'location' => '',
 		'uri' => '',


### PR DESCRIPTION
In the process of validating and classifying packages, it appears there is a Fatal Error in the SoapSource. This error may also exist in other datasources. Regardless, this patch fixes the fatal error caused by changing the property visibility from public (var => public) to protected.
