### PR TITLE
Property overriding

### DIFF
--- a/models/datasources/xmlrpc_source.php
+++ b/models/datasources/xmlrpc_source.php
@@ -53,7 +53,7 @@ class XmlrpcSource extends Datasource {
  *
  * @var array
  */
-	protected $_baseConfig = array(
+	public $_baseConfig = array(
 		'host' => '127.0.0.1',
 		'port' => 80,
 		'url' => '/RPC2',


### PR DESCRIPTION
When overriding a public property with a protected property, you'll get an error. Long live PHP4 BC compatibility! - NOT.
