### PR TITLE
Fixed usage of Model::field().

### DIFF
--- a/models/datasources/array_source.php
+++ b/models/datasources/array_source.php
@@ -143,7 +143,7 @@ class ArraySource extends Datasource {
 		// Filter fields
 		if (!empty($queryData['fields'])) {
 			$listOfFields = array();
-			foreach ($queryData['fields'] as $field) {
+			foreach ((array)$queryData['fields'] as $field) {
 				if (strpos($field, '.') !== false) {
 					list($alias, $field) = explode('.', $field, 2);
 					if ($alias !== $model->alias) {
@@ -196,10 +196,10 @@ class ArraySource extends Datasource {
 /**
  * Conditions Filter
  *
- * @param Model $model 
- * @param string $record 
- * @param array $conditions 
- * @param boolean $or 
+ * @param Model $model
+ * @param string $record
+ * @param array $conditions
+ * @param boolean $or
  * @return void
  */
 	public function conditionsFilter(&$model, $record, $conditions, $or = false) {

--- a/tests/cases/models/datasources/array_source.test.php
+++ b/tests/cases/models/datasources/array_source.test.php
@@ -225,6 +225,26 @@ class ArraySourceTest extends CakeTestCase {
 	}
 
 /**
+ * testField
+ *
+ * @return void
+ * @access public
+ */
+	function testField() {
+		$expected = 2;
+		$result = $this->Model->field('id', array('name' => 'Brazil'));
+		$this->assertEqual($result, $expected);
+
+		$expected = 'Germany';
+		$result = $this->Model->field('name', array('relate_id' => 2));
+		$this->assertEqual($result, $expected);
+
+		$expected = 'USA';
+		$result = $this->Model->field('name', array('relate_id' => 1));
+		$this->assertEqual($result, $expected);
+	}
+
+/**
  * testFindLimit
  *
  * @return void


### PR DESCRIPTION
Model::field() didn't work, because the datasource assumed it would always get an array of fields.
