### PR TITLE
Added 'ReturnDatesAsStrings' option to sqlsrv driver

### DIFF
--- a/models/datasources/dbo/dbo_sqlsrv.php
+++ b/models/datasources/dbo/dbo_sqlsrv.php
@@ -68,6 +68,7 @@ class DboSqlsrv extends DboSource {
 		'port' => '1433',
 		'mars' => false,
 		'charset' => SQLSRV_ENC_CHAR,
+                'ReturnDatesAsStrings' => true,
 	);
 
 /**


### PR DESCRIPTION
Just added the option to return date as string in sqlsrv driver.the default ie., in baseConfig set to true.
