### PR TITLE
Updated SQLite3 to allow UUID PK's

### DIFF
--- a/models/datasources/dbo/dbo_sqlite3.php
+++ b/models/datasources/dbo/dbo_sqlite3.php
@@ -73,7 +73,7 @@ class DboSqlite3 extends DboSource {
  * @access public
  */
 	var $columns = array(
-		'primary_key' => array('name' => 'primary key'),
+		'primary_key' => array('name' => 'integer primary key autoincrement'),
 		'string' => array('name' => 'varchar', 'limit' => '255'),
 		'text' => array('name' => 'text'),
 		'integer' => array('name' => 'integer', 'limit' => null, 'formatter' => 'intval'),


### PR DESCRIPTION
Fixed issues with table creation so default PK has type integer autoincrement

Original pull request was closed due to this issue, https://github.com/cakephp/datasources/pull/21
