### PR TITLE
Two bug fixes for sqlite3 database connector

### DIFF
--- a/models/datasources/dbo/dbo_sqlite3.php
+++ b/models/datasources/dbo/dbo_sqlite3.php
@@ -261,7 +261,13 @@ class DboSqlite3 extends DboSource {
 			return $cache;
 		}
 		
-		$result = $this->fetchAll("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;", false);
+               /**
+               * Bug fix in which SQL views are ignored
+               * To reproduce: create a new SQL view in the usual way. Then try to use it with your model.
+               * Result: Cakephp complains that there is no table for the selected model.
+               * System tested on: OSX 10.6, php 5.3.4, cake 1.3.12.
+               */
+		$result = $this->fetchAll("SELECT name FROM sqlite_master WHERE type='table' OR type='view' ORDER BY name;", false);
 
 		if (!$result || empty($result)) {
 			return array();


### PR DESCRIPTION
1) In the first instance, an invalid database configuration can sometimes result in a failure to connect to the SQLite database without an error. As no error is caught by CakePhP, PhP itself throws a fatal error on line 221 as no $connection object exists. This bug fix forces the _execute() function to check that the database is in fact connected - if not, CakePhP gracefully throws a helpful error message to the user.

Reported here: http://stackoverflow.com/questions/4779007/cakephp-and-sqlite-fatal-error-call-to-a-member-function-query-on-a-non-obje, here: http://stackoverflow.com/questions/7107996/fatal-error-call-to-a-member-function-query-on-a-non-object-in-var-www-likes, and here: http://stackoverflow.com/questions/7572091/error-while-trying-to-connect-to-sqlite3-database-from-cakephp
To reproduce: set $config['connect'] to an invalid value.

2) In the second instance, the sqlite driver ignores SQL views. Changing the SQL query to read "SELECT name FROM sqlite_master WHERE type='table' OR type='view'" where it previously read just "type='table'" fixes this problem.

All the best,

Daniel
