### PR TITLE
Adding $startQuote and $endQuote properties

### DIFF
--- a/Model/Datasource/SoapSource.php
+++ b/Model/Datasource/SoapSource.php
@@ -58,7 +58,21 @@ class SoapSource extends DataSource {
 		'uri' => '',
 		'login' => '',
 		'password' => '',
-		'authentication' => 'SOAP_AUTHENTICATION_BASIC');
+		'authentication' => 'SOAP_AUTHENTICATION_BASIC'
+	);
+
+    /**
+     * EndQuote
+     * @var string 
+     */
+    public $startQuote = null;
+
+    /**
+     * End Quote
+     * @var type 
+     */
+    public $endQuote = null;
+
 
 /**
  * Constructor


### PR DESCRIPTION
If undefined, PHP triggers a notice error.
There is an other issue if undefined, if cakephp debug mode is set to 2, the layout isn't displayed, probably due to a blank space.
