### PR TITLE
ArraySource tests

### DIFF
--- a/Model/Datasource/ArraySource.php
+++ b/Model/Datasource/ArraySource.php
@@ -146,7 +146,9 @@ class ArraySource extends DataSource {
 					if (strpos($field, ' ') !== false) {
 						list($field, $sort) = explode(' ', $field, 2);
 					}
-					$data = Set::sort($data, '{n}.' . $model->alias . '.' . $field, $sort);
+					if ($data) {
+						$data = Set::sort($data, '{n}.' . $model->alias . '.' . $field, $sort);
+					}
 				}
 			}
 		}
@@ -353,7 +355,7 @@ class ArraySource extends DataSource {
 						'recursive' => $recursive
 					));
 					$find = array(
-						$association => Set::extract('{n}.' . $association, $find)
+						$association => (array) Set::extract('{n}.' . $association, $find)
 					);
 				}
 			} elseif ($type === 'hasAndBelongsToMany' && array_key_exists($model->primaryKey, $result[$model->alias])) {
@@ -400,7 +402,7 @@ class ArraySource extends DataSource {
 		if ($clear) {
 			$this->_requestsLog = array();
 		}
-		return array('log' => $log, 'count' => count($log), 'time' => array_sum(Set::extract('{n}.took', $log)));
+		return array('log' => $log, 'count' => count($log), 'time' => array_sum((array) Set::extract('{n}.took', $log)));
 	}
 
 /**

--- a/Test/Case/Model/Datasource/ArraySourceTest.php
+++ b/Test/Case/Model/Datasource/ArraySourceTest.php
@@ -568,7 +568,7 @@ class ArraySourceTest extends CakeTestCase {
 	public function testDboToArrayHasOne() {
 		ClassRegistry::config(array());
 		$model = ClassRegistry::init('UserModel');
-		$model->unBindModel(array('hasMany' => array('Relate')), false);
+		$model->unBindModel(array('hasMany' => array('Relate'), 'belongsTo' => array('Born')), false);
 		$model->bindModel(array('hasOne' => array('Relate' => array('className' => 'ArrayModel', 'foreignKey' => 'relate_id'))), false);
 
 		$result = $model->find('all', array('recursive' => 1));
@@ -657,9 +657,11 @@ class ArraySourceTest extends CakeTestCase {
 	public function testArrayToArrayBelongsToWithoutForeignKey() {
 		ClassRegistry::config(array());
 		$model = ClassRegistry::init('ArrayModel');
+		$model->bindModel(array('belongsTo' => array('Relate' => array('className' => 'ArrayModel', 'foreignKey' => 'relate_id'))), false);
 
 		$result = $model->find('all', array(
-			'fields' => array('ArrayModel.id', 'ArrayModel.name')
+			'fields' => array('ArrayModel.id', 'ArrayModel.name'),
+			'recursive' => 0
 		));
 		$expected = array(
 			array(


### PR DESCRIPTION
The tests for the ArraySource weren't all being executed, because they were separated over serveral classes. Somehow PHPunit doesn't support that. This caused that a couple of bugs were unnoticed. Some of the unexecuted tests were actually failing.

This pull request fixes the execution of the tests and fixes the existing test cases that were failing.
