### PR TITLE
Robustify sqlite3 column name detection

### DIFF
--- a/models/datasources/dbo/dbo_sqlite3.php
+++ b/models/datasources/dbo/dbo_sqlite3.php
@@ -518,9 +518,9 @@ class DboSqlite3 extends DboSource {
 		//	so try to figure it out based on the querystring
 		$querystring = $results->queryString;
 		if (stripos($querystring, 'SELECT') === 0) {
-			$last = stripos($querystring, 'FROM');
+			$last = stripos($querystring, ' FROM ');
 			if ($last !== false) {
-				$selectpart = substr($querystring, 7, $last - 8);
+				$selectpart = substr($querystring, 7, $last - 7);
 				$selects = explode(',', $selectpart);
 			}
 		} elseif (strpos($querystring, 'PRAGMA table_info') === 0) {


### PR DESCRIPTION
Column names such as 'SENT_FROM' is not compatible with the current SQLite DBO. This is because it looks for the first occurence of 'FROM' in the query to figure out which part of the query contains the columns.

By changing the this to look for ' FROM ' (with spaces surrounding the FROM) we gain a bit of robustness. It will still not work with unlikely names such as 'SENT FROM EMAIL'.
