### PR TITLE
Fixed Strict Error by PHP 5.4 in SoapSource

### DIFF
--- a/Model/Datasource/SoapSource.php
+++ b/Model/Datasource/SoapSource.php
@@ -133,7 +133,7 @@ class SoapSource extends DataSource {
  *
  * @return array List of SOAP methods
  */
-	public function listSources() {
+	public function listSources($data = NULL) {
 		return $this->client->__getFunctions();
 	}
 	


### PR DESCRIPTION
PHP 5.4 was throwing the following Strict Error:

Declaration of SoapSource::listSources() should be compatible with
DataSource::listSources($data = NULL) in [..app/Plugin/Datasources
/Model/Datasource/SoapSource.php, line 27]
