### PR TITLE
Support key names of $records

### DIFF
--- a/models/datasources/array_source.php
+++ b/models/datasources/array_source.php
@@ -53,10 +53,20 @@ class ArraySource extends Datasource {
  * Returns a Model description (metadata) or null if none found.
  *
  * @param Model $model
- * @return array Show only id
+ * @return array Show id and etc.
  */
-	public function describe(&$model) {
-		return array('id' => array());
+	public function describe($model) {
+        $columns = array('id' => array());
+        foreach ($model->records as $pos => $record) {
+            $column_names = array_keys($record);
+
+            foreach($column_names as $column_name){
+                $columns[$column_name] = array();
+            }
+            break;
+        }
+
+        return $columns;
 	}
 
 /**


### PR DESCRIPTION
The current describe() function does't not support fields of $records array excluding id.
A generated view based on model using ArraySource with cake bake doesn't support fields of $records. So there's not any fields excluding id in a view.
I need input or output all fields of $records So I changed describe() function. 
