### PR TITLE
Fix problem which is data of array model removed when $listOfFields was empty.

### DIFF
--- a/Model/Datasource/ArraySource.php
+++ b/Model/Datasource/ArraySource.php
@@ -200,9 +200,11 @@ class ArraySource extends DataSource {
 				$listOfFields[] = $field;
 			}
 			foreach ($data as $id => $record) {
-				foreach ($record[$model->alias] as $field => $value) {
-					if (!in_array($field, $listOfFields)) {
-						unset($data[$id][$model->alias][$field]);
+				if( count($listOfFields) > 0 ){
+					foreach ($record[$model->alias] as $field => $value) {
+						if (!in_array($field, $listOfFields)) {
+							unset($data[$id][$model->alias][$field]);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
I defined models like below.
- Model A(based on DboSource)
- Model B(based on ArraySource)
- Relation: Model A belongsTo Model B

I encountered problem like below.
When I called `A-> find('all')` with `A->recursive = 2`, `ArraySource:: queryAssociation()` was called with `$queryData['fields']` which had fields related model A.

Because passed fields in `ArraySource::read()` were not existed in model B, `$listOfFields` in `ArraySource::read()` was empty. Therefore `ArraySource::read()` returned empty array.
