### PR TITLE
Make column detection more robust

### DIFF
--- a/Model/Datasource/Database/Sqlite3.php
+++ b/Model/Datasource/Database/Sqlite3.php
@@ -485,9 +485,9 @@ class DboSqlite3 extends DboSource {
 		//	so try to figure it out based on the querystring
 		$querystring = $results->queryString;
 		if (stripos($querystring, 'SELECT') === 0) {
-			$last = stripos($querystring, 'FROM');
+			$last = stripos($querystring, ' FROM');
 			if ($last !== false) {
-				$selectpart = substr($querystring, 7, $last - 8);
+				$selectpart = substr($querystring, 7, $last - 7);
 				$selects = explode(',', $selectpart);
 			}
 		} elseif (strpos($querystring, 'PRAGMA table_info') === 0) {


### PR DESCRIPTION
Prevent a field name containing the string "FROM" from borking the query
parsing. Not perfect, as a field named "SEND FROM" would still cause a
problem - but better than right now.

Extracted from #38.
