### PR TITLE
Describe returns proper schema and the schema is cached

### DIFF
--- a/Model/Datasource/CsvSource.php
+++ b/Model/Datasource/CsvSource.php
@@ -190,21 +190,21 @@ class CsvSource extends DataSource {
 		//pull the fields and build the schema
 		$this->_getDescriptionFromFirstLine($model);
 		$schema = array();
-		foreach($this->fields as $fieldname) {
+		foreach ($this->fields as $fieldname) {
 			$schema[$fieldname] = array(
-				'type'=>'text',
-				'null'=>true,
-				'default'=>null,
-				'length'=>null
+				'type' => 'text',
+				'null' => true,
+				'default' => null,
+				'length' => null
 			);
 		}
 		
 		//save to cache
 		$this->_cacheDescription($table, array(
-			'schema'=>$schema,
-			'fields'=>$this->fields,
-			'delimiter'=>$this->delimiter,
-			'maxCol'=>$this->maxCol
+			'schema' => $schema,
+			'fields' => $this->fields,
+			'delimiter' => $this->delimiter,
+			'maxCol' => $this->maxCol
 		));
 		
 		//return

--- a/Model/Datasource/CsvSource.php
+++ b/Model/Datasource/CsvSource.php
@@ -171,8 +171,44 @@ class CsvSource extends DataSource {
  * @return mixed
  */
 	public function describe($model) {
+		//get table name
+		if (is_string($model)) {
+			$table = $model;
+		} else {
+			$table = $model->table;
+		}
+		
+		//see if it's cached
+		$cache = parent::describe($table);
+		if ($cache) {
+			$this->fields = $cache['fields'];
+			$this->delimiter = $cache['delimiter'];
+			$this->maxCol = $cache['maxCol'];
+			return $cache['schema'];
+		}
+		
+		//pull the fields and build the schema
 		$this->_getDescriptionFromFirstLine($model);
-		return $this->fields;
+		$schema = array();
+		foreach($this->fields as $fieldname) {
+			$schema[$fieldname] = array(
+				'type'=>'text',
+				'null'=>true,
+				'default'=>null,
+				'length'=>null
+			);
+		}
+		
+		//save to cache
+		$this->_cacheDescription($table, array(
+			'schema'=>$schema,
+			'fields'=>$this->fields,
+			'delimiter'=>$this->delimiter,
+			'maxCol'=>$this->maxCol
+		));
+		
+		//return
+		return $schema;
 	}
 
 /**

--- a/Test/Case/Model/Datasource/CsvSourceTest.php
+++ b/Test/Case/Model/Datasource/CsvSourceTest.php
@@ -168,22 +168,22 @@ class CsvSourceTest extends CakeTestCase {
 		$model = ClassRegistry::init('UserTest');
 		$expected = array(
 			'id'=>array(
-				'type'=>'text',
-				'null'=>true,
-				'default'=>null,
-				'length'=>null
+				'type' => 'text',
+				'null' => true,
+				'default' => null,
+				'length' => null
 			),
 			'name'=>array(
-				'type'=>'text',
-				'null'=>true,
-				'default'=>null,
-				'length'=>null
+				'type' => 'text',
+				'null' => true,
+				'default' => null,
+				'length' => null
 			),
 			'age'=>array(
-				'type'=>'text',
-				'null'=>true,
-				'default'=>null,
-				'length'=>null
+				'type' => 'text',
+				'null' => true,
+				'default' => null,
+				'length' => null
 			)
 		);
 		$this->assertEquals($expected, $this->Csv->describe($model));

--- a/Test/Case/Model/Datasource/CsvSourceTest.php
+++ b/Test/Case/Model/Datasource/CsvSourceTest.php
@@ -167,7 +167,24 @@ class CsvSourceTest extends CakeTestCase {
 		ConnectionManager::create('test_csv', $this->config);
 		$model = ClassRegistry::init('UserTest');
 		$expected = array(
-			'id', 'name', 'age'
+			'id'=>array(
+				'type'=>'text',
+				'null'=>true,
+				'default'=>null,
+				'length'=>null
+			),
+			'name'=>array(
+				'type'=>'text',
+				'null'=>true,
+				'default'=>null,
+				'length'=>null
+			),
+			'age'=>array(
+				'type'=>'text',
+				'null'=>true,
+				'default'=>null,
+				'length'=>null
+			)
 		);
 		$this->assertEquals($expected, $this->Csv->describe($model));
 	}


### PR DESCRIPTION
Per "Model/Datasource/DataSource.php", describe should return a metadata array, not a list of fields.  When proper metadata isn't returned by describe, other functionality (such as $model->getColumnTypes()), is broken.  Many behaviors depend on these core functions returning properly.

This patch also makes use of the built in schema caching provided by Cake2.
