### PR TITLE
Make ArraySource compatible with CakePHP2.5.2

### DIFF
--- a/Model/Datasource/ArraySource.php
+++ b/Model/Datasource/ArraySource.php
@@ -107,6 +107,15 @@ class ArraySource extends DataSource {
 	}
 
 /**
+ * Implemented to make the datasource work with CaKePHP 2.5.2
+ *
+ * @return boolean Always true;
+ */
+    public function isConnected() {
+        return true;
+    }
+
+/**
  * Used to read records from the Datasource. The "R" in CRUD
  *
  * @param Model $model The model being read.


### PR DESCRIPTION
Added isConnected function to ArraySource so it is compatible with CakePHP 2.5.2

Resolves https://github.com/cakephp/datasources/issues/107
