### PR TITLE
LdapSource: Remove call to undefined fatal_error() function

### DIFF
--- a/Model/Datasource/LdapSource.php
+++ b/Model/Datasource/LdapSource.php
@@ -230,7 +230,7 @@ class LdapSource extends DataSource {
 		if ($config['tls']) {
 			if (!ldap_start_tls($this->database)) {
 				$this->log("Ldap_start_tls failed", 'ldap.error');
-				fatal_error("Ldap_start_tls failed");
+				return $this->disconnect();
 			}
 		}
 		//So little known fact, if your php-ldap lib is built against openldap like pretty much every linux


### PR DESCRIPTION
The function `fatal_error()` is not defined; Disconnecting and returning to the caller is probably preferred anyway.