### PR TITLE
 Fix basic CRUD operations of LdapSource not working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,50 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
+  - 5.6
+  - 7.1
+
+addons:
+  apt_packages:
+    - ldap-utils
+    - slapd
 
 env:
   global:
     - PLUGIN_NAME=Datasources
     - REQUIRE=""
+    - DB=mysql
+    - COMPOSER_HOME=/home/travis/.composer
 
   matrix:
-    - DB=mysql CAKE_VERSION=2.3
-    - DB=mysql CAKE_VERSION=2.4
-    - DB=mysql CAKE_VERSION=2.5
+    - CAKE_VERSION=2.10
 
 matrix:
   include:
-    - php: 5.4
+    - php: 5.6
+      env:
+        - CAKE_REF=2.6.13
+    - php: 5.6
+      env:
+        - CAKE_REF=2.7.11
+    - php: 7.1
+      env:
+        - CAKE_REF=2.8.9
+    - php: 7.1
+      env:
+        - CAKE_REF=2.9.9
+    - php: 7.1
       env:
         - PHPCS=1
   allow_failures:
-    - php: 5.4
+    - php: 7.1
       env:
         - PHPCS=1
+
+before_install:
+  - sudo ldapmodify -Y EXTERNAL -H ldapi:// -f Test/Ldap/config.ldif
+  - sudo ldapmodify -D cn=config -f Test/Ldap/admin.ldif -w password
+  - sudo ldapadd -D cn=admin,dc=cakephp,dc=org -f Test/Ldap/database.ldif -w password
 
 before_script:
   - git clone https://github.com/FriendsOfCake/travis.git --depth 1 ../travis

--- a/Model/Datasource/ArraySource.php
+++ b/Model/Datasource/ArraySource.php
@@ -166,6 +166,11 @@ class ArraySource extends DataSource {
 		}
 		// Order
 		if (!empty($queryData['order'])) {
+			// For CakePHP >= 2.8
+			if (!isset($queryData['order'][0])) {
+				$queryData['order'] = array($queryData['order']);
+			}
+
 			if (is_string($queryData['order'][0])) {
 				$field = $queryData['order'][0];
 				$alias = $model->alias;

--- a/Model/Datasource/LdapSource.php
+++ b/Model/Datasource/LdapSource.php
@@ -139,7 +139,7 @@ class LdapSource extends DataSource {
  */
 	protected $_queriesLog = array();
 
-	/**
+/**
  * Total duration of all queries.
  *
  * @var int
@@ -258,7 +258,7 @@ class LdapSource extends DataSource {
 		//So little known fact, if your php-ldap lib is built against openldap like pretty much every linux
 		//distro out their like redhat, suse etc. The connect doesn't acutally happen when you call ldap_connect
 		//it happens when you call ldap_bind.  So if you are using failover then you have to test here also.
-		$bindResult = @ldap_bind($this->database, $bindDN, $bindPasswd);
+		$bindResult = @ldap_bind($this->database, $bindDN, $bindPasswd); // @codingStandardsIgnoreLine
 		if (!$bindResult) {
 			if (ldap_errno($this->database) == 49) {
 				$this->log("Auth failed for '$bindDN'!", 'ldap.error');
@@ -299,6 +299,7 @@ class LdapSource extends DataSource {
  * Disconnects database, kills the connection and says the connection is closed,
  * and if DEBUG is turned on, the log for this object is shown.
  *
+ * @return void
  */
 	public function close() {
 		if ($this->fullDebug && Configure::read('debug') > 1) {
@@ -309,6 +310,7 @@ class LdapSource extends DataSource {
 
 /**
  * disconnect  close connection and release any remaining results in the buffer
+ *
  * @return bool The connection status
  */
 	public function disconnect() {
@@ -348,7 +350,7 @@ class LdapSource extends DataSource {
 /**
  * The "C" in CRUD
  *
- * @param Model $model
+ * @param Model $model The model to be created.
  * @param array $fields The field names
  * @param array $values The fields' values
  * @return bool True on success, false on error
@@ -406,9 +408,10 @@ class LdapSource extends DataSource {
 
 /**
  * Returns the query
- * @param string $find
+ *
+ * @param string $find The name of the query
  * @param mixed $query The query as a string or single-element array
- * @param Model $model
+ * @param Model $model The model being queried
  * @return mixed
  */
 	public function query($find, $query, $model) {
@@ -437,8 +440,8 @@ class LdapSource extends DataSource {
 /**
  * The "R" in CRUD
  *
- * @param Model $model
- * @param array $queryData
+ * @param Model $model The model being read.
+ * @param array $queryData An array of query data used to find the data you want
  * @param int $recursive Number of levels of association
  * @return mixed Resultset or false on error
  */
@@ -519,10 +522,11 @@ class LdapSource extends DataSource {
 
 /**
  * The "U" in CRUD
- * 
- * @param Model $model
- * @param array $fields
- * @param int $values
+ *
+ * @param Model $model The model being updated.
+ * @param array $fields  Array of fields to be updated
+ * @param int $values Array of values to be update $fields to.
+ * @param mixed $conditions *unused*
  * @return bool Success
  */
 	public function update(Model $model, $fields = null, $values = null, $conditions = null) {
@@ -587,7 +591,9 @@ class LdapSource extends DataSource {
 
 /**
  * The "D" in CRUD
- * @param Model $model
+ *
+ * @param Model $model The model class having record(s) deleted
+ * @param mixed $conditions *unused*
  * @return bool Success
  */
 	public function delete(Model $model, $conditions = null) {
@@ -633,8 +639,10 @@ class LdapSource extends DataSource {
 
 /**
  * Recursive delete
+ *
  * Courtesy of gabriel at hrz dot uni-marburg dot de @ http://ar.php.net/ldap_delete
- * @param string $dn
+ *
+ * @param string $dn The DN to be deleted recursively.
  * @return bool Success
  */
 	protected function _deleteRecursively($dn) {
@@ -654,15 +662,15 @@ class LdapSource extends DataSource {
 
 /**
  * Generate query parameters for an association
- * 
+ *
  * @param Model $model The source model
  * @param Model $linkModel The associated model
  * @param string $type The type of association
  * @param array $association *unused*
  * @param array $assocData The model association parameters
- * @param array $queryData The associative array to modify
+ * @param array &$queryData The associative array to modify
  * @param array $external *unused*
- * @param array $resultSet The source model data
+ * @param array &$resultSet The source model data
  * @return mixed Array or null on failure
  */
 	public function generateAssociationQuery(Model $model, Model $linkModel, $type, $association, $assocData, &$queryData, $external, &$resultSet) {
@@ -704,15 +712,15 @@ class LdapSource extends DataSource {
 
 /**
  * Query an associated model
- * 
+ *
  * @param Model $model The source model
- * @param Model $linkModel The associated model
+ * @param Model &$linkModel The associated model
  * @param string $type The type of association
- * @param array $association
+ * @param array $association Association name
  * @param array $assocData The model association parameters
- * @param array $queryData The associative array to modify
- * @param array $external
- * @param array $resultSet The source model data
+ * @param array &$queryData The associative array to modify
+ * @param array $external *unused*
+ * @param array &$resultSet The source model data
  * @param int $recursive The depth of recursion
  * @param array $stack The source model data
  * @return mixed Array or null on failure
@@ -781,6 +789,7 @@ class LdapSource extends DataSource {
  * Returns number of rows in previous resultset. If no previous resultset exists,
  * this returns false.
  *
+ * @param mixed $source *unused*
  * @return int Number of rows in resultset
  */
 	public function lastNumRows($source = null) {
@@ -804,6 +813,8 @@ class LdapSource extends DataSource {
 	}
 
 /**
+ * Returns LDAP scheme information
+ *
  * The following was kindly "borrowed" from the excellent phpldapadmin project
  *
  * @return array
@@ -931,12 +942,12 @@ class LdapSource extends DataSource {
 	}
 
 /**
- * LdapSource::_parseList()
+ * Parse LDAP schema strings
  *
- * @param int $i
- * @param array $strings
- * @param array $attrs
- * @return int
+ * @param int $i The index of $strings to be parsed.
+ * @param array $strings LDAP schema strings.
+ * @param array &$attrs The reference variable to be filled with the results of parsing.
+ * @return int The next index of $strings to be parsed.
  */
 	protected function _parseList($i, $strings, &$attrs) {
 	/**
@@ -991,6 +1002,9 @@ class LdapSource extends DataSource {
 
 /**
  * Function not supported
+ *
+ * @param string $query *unused*
+ * @return null
  */
 	public function execute($query) {
 		return null;
@@ -998,6 +1012,10 @@ class LdapSource extends DataSource {
 
 /**
  * Function not supported
+ *
+ * @param string $query *unused*
+ * @param bool $cache *unused*
+ * @return array
  */
 	public function fetchAll($query, $cache = true) {
 		return array();
@@ -1007,7 +1025,8 @@ class LdapSource extends DataSource {
  * Log given LDAP query.
  *
  * @param string $query LDAP statement
- * @todo: Add hook to log errors instead of returning false
+ * @todo Add hook to log errors instead of returning false
+ * @return void
  */
 	public function logQuery($query) {
 		$this->_queriesCnt++;
@@ -1027,7 +1046,8 @@ class LdapSource extends DataSource {
 /**
  * Outputs the contents of the queries log.
  *
- * @param bool $sorted
+ * @param bool $sorted Get the queries sorted by time taken, defaults to false.
+ * @return void
  */
 	public function showLog($sorted = false) {
 		if ($sorted) {
@@ -1062,6 +1082,7 @@ class LdapSource extends DataSource {
  * and execution time in microseconds. If the query fails, an error is output instead.
  *
  * @param string $query Query to show information on.
+ * @return void
  */
 	public function showQuery($query) {
 		$error = $this->error;
@@ -1080,9 +1101,9 @@ class LdapSource extends DataSource {
 
 /**
  * Filter conditions to remove SQL-like naming conventions
- * 
+ *
  * @param mixed $conditions Array or string
- * @param Model $model
+ * @param Model $model The model
  * @return string
  */
 	protected function _conditions($conditions, $model) {
@@ -1183,10 +1204,10 @@ class LdapSource extends DataSource {
 		}
 	}
 
-/** 
+/**
  * Look for the base DN in the target DN
- * 
- * @param string $targetDN
+ *
+ * @param string $targetDN The target DN
  * @return bool
  */
 	public function checkBaseDn($targetDN) {
@@ -1195,10 +1216,11 @@ class LdapSource extends DataSource {
 		return preg_match($pattern, $targetDN);
 	}
 
-/** 
- * 
- * @param array $queryData
- * @param bool $cache
+/**
+ * Execcutes query
+ *
+ * @param array $queryData An array of query data
+ * @param bool $cache Whether or not the result of query should be cached
  * @return mixed LDAP resource or false on error
  */
 	protected function _executeQuery($queryData = array(), $cache = true) {
@@ -1248,7 +1270,7 @@ class LdapSource extends DataSource {
 							$queryData['fields'] = array();
 						}
 						// Use error control operator to suppress output of sizelimit exceeded message when sizelimit is used.
-						$res = @ldap_search($this->database, $queryData['targetDn'], $queryData['conditions'], $queryData['fields'], 0, $queryData['limit']);
+						$res = @ldap_search($this->database, $queryData['targetDn'], $queryData['conditions'], $queryData['fields'], 0, $queryData['limit']);  // @codingStandardsIgnoreLine
 					}
 
 					if (!$res) {
@@ -1289,8 +1311,8 @@ class LdapSource extends DataSource {
 
 /**
  * Convert a query arry to a string
- * 
- * @param array $queryData
+ *
+ * @param array $queryData An array of query data
  * @return string
  */
 	protected function _queryToString($queryData) {
@@ -1320,10 +1342,10 @@ class LdapSource extends DataSource {
 	}
 
 /**
- * LdapSource::_ldapFormat()
+ * Format results of ldap_get_entries()
  *
- * @param Model $model
- * @param array $data
+ * @param Model $model The model
+ * @param array $data Results of ldap_get_entries()
  * @return array
  */
 	protected function _ldapFormat(Model $model, $data) {
@@ -1359,7 +1381,7 @@ class LdapSource extends DataSource {
 /**
  * Escape special characters for LDAP query
  *
- * @param string $str
+ * @param string $str The input string
  * @return string
  */
 	protected function _ldapQuote($str) {
@@ -1372,11 +1394,12 @@ class LdapSource extends DataSource {
 
 /**
  * Modify $data array to add in association information
- * 
- * @param array $data
- * @param array $merge
- * @param string $association
- * @param string $type
+ *
+ * @param array &$data The data to merge.
+ * @param array $merge The data to merge.
+ * @param string $association The association name to merge.
+ * @param string $type The type of association
+ * @return void
  */
 	protected function _mergeAssociation(&$data, $merge, $association, $type) {
 		if (isset($merge[0]) && !isset($merge[0][$association])) {
@@ -1424,7 +1447,7 @@ class LdapSource extends DataSource {
 /**
  * Private helper method to remove query metadata in given data array.
  *
- * @param array $data
+ * @param array &$data The data to scrub.
  * @return void
  */
 	protected function _scrubQueryData(&$data) {
@@ -1450,6 +1473,7 @@ class LdapSource extends DataSource {
 
 /**
  * Return LDAP object classes, cache results
+ *
  * @return array
  */
 	protected function _getObjectClasses() {
@@ -1476,6 +1500,11 @@ class LdapSource extends DataSource {
 		return $objectclasses;
 	}
 
+/**
+ * Function not supported
+ *
+ * @return null
+ */
 	public function boolean() {
 		return null;
 	}
@@ -1483,7 +1512,7 @@ class LdapSource extends DataSource {
 /**
  * Returns an calculation
  *
- * @param model $model
+ * @param model $model The model to get a calculated field for.
  * @param string $func Lowercase name of SQL function, i.e. 'count' or 'max'
  * @param array $params Function parameters (any values must be quoted manually)
  * @return null
@@ -1493,10 +1522,10 @@ class LdapSource extends DataSource {
 	}
 
 /**
- * LdapSource::describe()
+ * Returns a Model description (metadata) or null if none found.
  *
- * @param mixed $model
- * @param string $field
+ * @param mixed $model The model to describe.
+ * @param string $field Array of Metadata for the $model
  * @return array
  */
 	public function describe($model, $field = null) {
@@ -1510,10 +1539,10 @@ class LdapSource extends DataSource {
 	}
 
 /**
- * LdapSource::inArrayInsensitive()
+ * Checks if a key or value exists in an array case-insensitively.
  *
- * @param string $needle
- * @param array $haystack
+ * @param string $needle The searched value.
+ * @param array $haystack The array.
  * @return bool
  */
 	public function inArrayInsensitive($needle, $haystack) {
@@ -1529,7 +1558,7 @@ class LdapSource extends DataSource {
 	}
 
 /**
- * LdapSource::defaultNSAttributes()
+ * Returns default attributes for search queries.
  *
  * @return array
  */
@@ -1541,6 +1570,7 @@ class LdapSource extends DataSource {
 /**
  * debugLDAPConnection debugs the current connection to check the settings
  *
+ * @return void
  */
 	public function debugLDAPConnection() {
 		$opts = array('LDAP_OPT_DEREF', 'LDAP_OPT_SIZELIMIT', 'LDAP_OPT_TIMELIMIT', 'LDAP_OPT_NETWORK_TIMEOUT',
@@ -1570,6 +1600,8 @@ class LdapSource extends DataSource {
 
 /**
  * Set default options for Microsoft Active Directory
+ *
+ * @return void
  */
 	public function setActiveDirectoryEnv() {
 		//Need to disable referals for AD
@@ -1581,6 +1613,8 @@ class LdapSource extends DataSource {
 
 /**
  * Set default options for OpenLDAP
+ *
+ * @return void
  */
 	public function setOpenLDAPEnv() {
 		$this->OperationalAttributes = ' + ';
@@ -1588,6 +1622,8 @@ class LdapSource extends DataSource {
 
 /**
  * Assign the schema patch from the server
+ *
+ * @return void
  */
 	public function setSchemaPath() {
 		$checkDN = ldap_read($this->database, '', 'objectClass=*', array('subschemaSubentry'));

--- a/Test/Case/Model/Datasource/LdapSourceTest.php
+++ b/Test/Case/Model/Datasource/LdapSourceTest.php
@@ -1,0 +1,275 @@
+<?php
+/**
+ * LDAP Datasource Test file
+ *
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP Datasources v 0.3
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+App::uses('ConnectionManager', 'Model');
+App::uses('Model', 'Model');
+
+/**
+ * Import required classes
+ *
+ */
+class LdapPerson extends Model {
+
+	public $useDbConfig = 'test_ldap';
+
+	public $useTable = 'ou=ldap_people';
+
+	public $primaryKey = 'cn';
+}
+
+class LdapSourceTest extends CakeTestCase {
+
+	public $autoFixtures = false;
+
+	public $fixtures = array('plugin.Datasources.ldapPerson');
+
+/**
+ * setUp method
+ *
+ * @return void
+ */
+	public function setUp() {
+		parent::setUp();
+
+		$config = array(
+			'datasource' => 'Datasources.LdapSource',
+			'host' => '127.0.0.1',
+			'port' => 389,
+			'login' => 'cn=admin,dc=cakephp,dc=org',
+			'password' => 'password',
+			'basedn' => 'dc=cakephp,dc=org',
+			'version' => 3,
+			'tls' => false,
+			'database' => '',
+		);
+
+		$this->loadLdapFixtures($config);
+
+		$ldap = ConnectionManager::create('test_ldap', $config);
+		if ($ldap) {
+			$ldap->cacheSources = false;
+			$ldap->fullDebug = false;
+		}
+
+		CakeLog::disable('stderr');
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		ConnectionManager::drop('test_ldap');
+		CakeLog::enable('stderr');
+	}
+
+	public function loadLdapFixtures($config) {
+		$ldap = ldap_connect($config['host'], $config['port']);
+
+		ldap_set_option($ldap, LDAP_OPT_PROTOCOL_VERSION, $config['version']);
+
+		if (!ldap_bind($ldap, $config['login'], $config['password'])) {
+			$this->markTestSkipped('Could not connect to LDAP server. Skip test.');
+		}
+
+		// Retrieve fixture objects
+		$prop = new ReflectionProperty($this->fixtureManager, '_loaded');
+		$prop->setAccessible(true);
+		$loaded = $prop->getValue($this->fixtureManager);
+
+		$tables = array();
+
+		$result = ldap_list($ldap, $config['basedn'], 'objectClass=organizationalUnit');
+		for ($entry = ldap_first_entry($ldap, $result); $entry; $entry = ldap_next_entry($ldap, $entry)) {
+			$tables[] = ldap_get_dn($ldap, $entry);
+		}
+		ldap_free_result($result);
+
+		foreach ($this->fixtures as $name) {
+			$fixture = $loaded[$name];
+
+			$table = 'ou=' . $fixture->table . ',' . $config['basedn'];
+
+			// DROP TABLE
+			if (in_array($table, $tables, true)) {
+				$result = ldap_search($ldap, $table, 'objectclass=*');
+				$dns = array();
+				for ($entry = ldap_first_entry($ldap, $result); $entry; $entry = ldap_next_entry($ldap, $entry)) {
+					$dns[] = ldap_get_dn($ldap, $entry);
+				}
+				ldap_free_result($result);
+
+				foreach (array_reverse($dns) as $dn) {
+					ldap_delete($ldap, $dn);
+				}
+			}
+
+			// CREATE TABLE
+			ldap_add($ldap, $table, array('objectclass' => 'organizationalUnit', 'ou' => $fixture->table));
+
+			// INSERT
+			foreach ($fixture->records as $record) {
+				$dn = $fixture->primaryKey . '=' . $record[$fixture->primaryKey] . ',' . $table;
+				ldap_add($ldap, $dn, $record);
+			}
+		}
+
+		ldap_close($ldap);
+	}
+
+	public function testIsConnected() {
+		$ldap = ConnectionManager::getDataSource('test_ldap');
+		$this->assertTrue($ldap->isConnected());
+	}
+
+	public function testDisconnect() {
+		$ldap = ConnectionManager::getDataSource('test_ldap');
+		$ldap->disconnect();
+		$this->assertFalse($ldap->isConnected());
+	}
+
+	public function testFind() {
+		$model = new LdapPerson();
+
+		$people = $model->find('all', array(
+			'conditions' => array('sn' => 'Doe'),
+		));
+
+		$expected = array(
+			array(
+				'LdapPerson' => array(
+					'dn' => 'cn=jane,ou=ldap_people,dc=cakephp,dc=org',
+					'objectclass' => 'person',
+					'cn' => 'jane',
+					'sn' => 'doe',
+				),
+				array(
+					'count' => 2,
+				),
+			),
+			array(
+				'LdapPerson' => array(
+					'dn' => 'cn=john,ou=ldap_people,dc=cakephp,dc=org',
+					'objectclass' => 'person',
+					'cn' => 'john',
+					'sn' => 'doe',
+				),
+			),
+		);
+
+		$this->assertEquals($expected, $people);
+	}
+
+	public function testSaveCreate() {
+		$model = new LdapPerson();
+
+		$data = array(
+			'objectclass' => 'person',
+			'cn' => 'foo',
+			'sn' => 'bar',
+		);
+
+		$model->save($data);
+
+		$person = $model->read();
+
+		$expected = array(
+			'LdapPerson' => array(
+				'dn' => 'cn=foo,ou=ldap_people,dc=cakephp,dc=org',
+				'objectclass' => 'person',
+				'cn' => 'foo',
+				'sn' => 'bar',
+			),
+			array(
+				'count' => 1,
+			),
+		);
+
+		$this->assertEquals($expected, $person);
+	}
+
+	public function testSaveUpdate() {
+		$model = new LdapPerson();
+
+		$data = array(
+			'cn' => 'john',
+			'sn' => 'smith',
+		);
+
+		$model->save($data);
+
+		$person = $model->find('first', array(
+			'conditions' => array('cn' => 'john'),
+		));
+
+		$expected = array(
+			'LdapPerson' => array(
+				'dn' => 'cn=john,ou=ldap_people,dc=cakephp,dc=org',
+				'objectclass' => 'person',
+				'cn' => 'john',
+				'sn' => 'smith',
+			),
+			array(
+				'count' => 1,
+			),
+		);
+
+		$this->assertEquals($expected, $person);
+	}
+
+	public function testDelete() {
+		$model = new LdapPerson();
+		$model->delete('john');
+
+		$person = $model->find('first', array(
+			'conditions' => array('cn' => 'john'),
+		));
+
+		$this->assertSame(array(), $person);
+	}
+
+	public function testFindSchema() {
+		$model = new LdapPerson();
+		$schema = $model->findSchema();
+
+		$expected = array(
+			'oid' => '2.5.6.6',
+			'name' => 'person',
+			'description' => "'RFC2256: a person'",
+			'sup_classes' => array('top'),
+			'type' => 'structural',
+			'must' => array('cn', 'sn'),
+			'may' => array('description', 'seeAlso', 'telephoneNumber', 'userPassword'),
+		);
+
+		$this->assertEquals($expected, $schema['objectclasses']['person']);
+	}
+
+	public function testConvertTimestampADToUnix() {
+		$ldap = ConnectionManager::getDataSource('test_ldap');
+		$time = $ldap->convertTimestampADToUnix('131277152960000000');
+		$this->assertEquals(1483241696, $time);
+	}
+
+	public function testGetNumRows() {
+		$model = new LdapPerson();
+
+		$model->find('all', array(
+			'conditions' => array('sn' => 'Doe'),
+		));
+
+		$this->assertEquals(2, $model->getNumRows());
+	}
+}

--- a/Test/Case/Model/Datasource/XmlrpcSourceTest.php
+++ b/Test/Case/Model/Datasource/XmlrpcSourceTest.php
@@ -295,9 +295,9 @@ class XmlrpcSourceTest extends CakeTestCase {
 
 		// Not XML-RPC Response
 		$config = array(
-			'host' => 'rss1.smashingmagazine.com',
+			'host' => 'www.w3.org',
 			'port' => 80,
-			'url' => '/feed/'
+			'url' => '/TR/1999/REC-xpath-19991116.xml'
 		);
 		$Xmlrpc = new XmlrpcSource($config);
 		$this->assertFalse($Xmlrpc->query('examples.getStateName', array(1)));

--- a/Test/Fixture/LdapPersonFixture.php
+++ b/Test/Fixture/LdapPersonFixture.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * LdapPerson Fixture
+ *
+ * PHP versions 4 and 5
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP Datasources v 0.3
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+/**
+ * LdapPerson Fixture
+ *
+ */
+class LdapPersonFixture extends CakeTestFixture {
+
+	public $primaryKey = 'cn';
+
+/**
+ * records property
+ *
+ * @var array
+ */
+	public $records = array(
+		array('objectclass' => 'person', 'cn' => 'jane', 'sn' => 'doe'),
+		array('objectclass' => 'person', 'cn' => 'john', 'sn' => 'doe'),
+		array('objectclass' => 'person', 'cn' => 'nanashi ', 'sn' => 'nanashi'),
+	);
+}

--- a/Test/Ldap/admin.ldif
+++ b/Test/Ldap/admin.ldif
@@ -1,0 +1,18 @@
+dn: olcDatabase={1}hdb,cn=config
+changetype: modify
+replace: olcSuffix
+olcSuffix: dc=cakephp,dc=org
+
+dn: olcDatabase={1}hdb,cn=config
+changetype: modify
+replace: olcRootDN
+olcRootDN: cn=admin,dc=cakephp,dc=org
+
+dn: olcDatabase={1}hdb,cn=config
+changetype: modify
+replace: olcRootPW
+olcRootPW: password
+
+dn: olcDatabase={1}hdb,cn=config
+changetype: modify
+delete: olcAccess

--- a/Test/Ldap/config.ldif
+++ b/Test/Ldap/config.ldif
@@ -1,0 +1,4 @@
+dn: olcDatabase={0}config,cn=config
+changetype: modify
+add: olcRootPW
+olcRootPW: password

--- a/Test/Ldap/database.ldif
+++ b/Test/Ldap/database.ldif
@@ -1,0 +1,5 @@
+dn: dc=cakephp,dc=org
+objectclass: dcObject
+objectclass: organization
+o: CakePHP
+dc: cakephp


### PR DESCRIPTION
This pull request contains the following fixes:
- Fix incorrect method signatures
- Fix use of undefined properties
- Fix calculate() not working
- Add default value to SchemaFilter
- Add test cases
- Make ArraySource compatible with CakePHP >= 2.8.
- Fix XmlrpcSourceTest not passing.

If there are no problems, I will merge this pull request few days later.